### PR TITLE
fix paths

### DIFF
--- a/demo.lua
+++ b/demo.lua
@@ -66,15 +66,15 @@ function key(n, z)
 end
 
 function init()
-  mistral = screen.load_png(paths.this.pat .. "mistral-digits.png")
+  mistral = screen.load_png(paths.this.path .. "lib/image/mistral-digits.png")
   print("image name: ", mistral:name())
   print("image size: ", mistral:extents())
   digit_width, digit_height = mistral:extents()
   digit_width = digit_width / 10.0
 
-  hairs_a = screen.load_png(paths.this.path .. "hairs-only-positive.png")
-  hairs_b = screen.load_png(paths.this.path .. "hairs-only-dim.png")
-  hairs_top = screen.load_png(paths.this.path .. "hairs-top-darker.png")
+  hairs_a = screen.load_png(paths.this.path .. "lib/image/hairs-only-positive.png")
+  hairs_b = screen.load_png(paths.this.path .. "lib/image/hairs-only-dim.png")
+  hairs_top = screen.load_png(paths.this.path .. "lib/image/hairs-top-darker.png")
     
   redraw_clock = clock.run(function()
     local interval = 1/15


### PR DESCRIPTION
two other issues:

# screen.scale()

`screen.scale()` isn't available for me on `220321`. here's what `screen` has according to `tabutil.print(screen)`:

```
aa
text_center
draw_to
pixel
curve
create_image
font_face
level
save
display_image_region
text_right
close
line_cap
text_extents
curve_rel
text
line_join
fill
translate
text_center_rotate
circle
display_image
stroke
rect
ping
blend_mode
BLEND_MODES
update
restore
line_width
rotate
peek
load_png
display_png
line
move
arc
font_size
poke
miter_limit
move_rel
text_rotate
update_default
clear
line_rel
update_low_battery
```

# screen.display_image_region()

with the above `screen.scale()` line commented out i get this error:

```
# script init
image name:     /home/we/dust/code/image_demo/lib/image/mistral-digits.png
image size:     200     40
lua: /home/we/norns/lua/core/screen.lua:336: attempt to call a nil value (field 'screen_display_image_region')
stack traceback:
        /home/we/norns/lua/core/screen.lua:336: in function 'core/screen.display_image_region'
        /home/we/dust/code/image_demo/demo.lua:27: in function 'core/script.redraw'
        /home/we/norns/lua/core/menu.lua:160: in field 'set_mode'
        /home/we/norns/lua/core/menu.lua:96: in field 'init_done'
        /home/we/norns/lua/core/engine.lua:92: in function </home/we/norns/lua/core/engine.lua:89>
lua: /home/we/norns/lua/core/clock.lua:65: /home/we/norns/lua/core/screen.lua:336: attempt to call a nil value (field 'screen_display_image_region')
stack traceback:
        [C]: in function 'error'
        /home/we/norns/lua/core/clock.lua:65: in function 'core/clock.resume'
```
i started to debug but didn't get very far